### PR TITLE
fix(makefile): remove surplus dry-run and fixed typo in build-installer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,12 +220,6 @@ bundle-build: ## Build the bundle image.
 bundle-push: ## Push the bundle image.
 	$(MAKE) docker-push IMG=$(BUNDLE_IMG)
 
-.PHONY: dry-run
-dry-run: manifests kustomize
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	mkdir -p ./dry-run
-	$(KUSTOMIZE) build config/default > dry-run/manifests.yaml
-
 .PHONY: opm
 OPM = ./bin/opm
 opm: ## Download opm locally if necessary.
@@ -271,4 +265,4 @@ catalog-push: ## Push a catalog image.
 build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
 	mkdir -p dist
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default > dist/install.yam
+	$(KUSTOMIZE) build config/default > dist/install.yaml

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
       [
         "@semantic-release/exec",
         {
-          "prepareCmd": "VERSION=${nextRelease.version} make dry-run"
+          "prepareCmd": "VERSION=${nextRelease.version} make build-installer"
         }
       ],
       [
@@ -38,7 +38,7 @@
         {
           "assets": [
             {
-              "path": "dry-run/manifests.yaml",
+              "path": "dist/install.yaml",
               "name": "install-${nextRelease.gitTag}.yaml",
               "label": "install-${nextRelease.gitTag}.yaml"
             }


### PR DESCRIPTION
This pull request includes changes to the `Makefile` to clean up and fix some issues related to image building and pushing. The most important changes include removing the `dry-run` target and correcting a typo in the `build-installer` target.

Makefile cleanup and fixes:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L223-L228): Removed the `dry-run` target, which included commands for generating a dry-run manifest.
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L274-R268): Corrected a typo in the `build-installer` target, changing `dist/install.yam` to `dist/install.yaml`.