### PR TITLE
fix: deletion blocked

### DIFF
--- a/internal/controller/checkly/utils.go
+++ b/internal/controller/checkly/utils.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package checkly
+
+import "strings"
+
+// isNotFoundError checks if an error represents a resource not found (404) error
+func isNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	errMsg := strings.ToLower(err.Error())
+	return strings.Contains(errMsg, "404") ||
+		strings.Contains(errMsg, "not found") ||
+		strings.Contains(errMsg, "does not exist")
+}

--- a/internal/controller/checkly/utils_test.go
+++ b/internal/controller/checkly/utils_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package checkly
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestIsNotFoundError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "404 error",
+			err:      errors.New("404 Not Found"),
+			expected: true,
+		},
+		{
+			name:     "not found error",
+			err:      errors.New("resource not found"),
+			expected: true,
+		},
+		{
+			name:     "does not exist error",
+			err:      errors.New("check does not exist"),
+			expected: true,
+		},
+		{
+			name:     "mixed case 404",
+			err:      errors.New("Error: 404 - Resource Not Found"),
+			expected: true,
+		},
+		{
+			name:     "mixed case not found",
+			err:      errors.New("Item NOT FOUND in database"),
+			expected: true,
+		},
+		{
+			name:     "other error",
+			err:      errors.New("internal server error"),
+			expected: false,
+		},
+		{
+			name:     "500 error",
+			err:      errors.New("500 Internal Server Error"),
+			expected: false,
+		},
+		{
+			name:     "authorization error",
+			err:      errors.New("401 Unauthorized"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isNotFoundError(tt.err)
+			if result != tt.expected {
+				t.Errorf("isNotFoundError(%v) = %v, expected %v", tt.err, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Overview

Attempt to fix https://github.com/checkly/checkly-operator/issues/59

**Note:** I've been experimenting with claude code to solve this issue - if the implementation seems non-sensical or would take a long time to correct, please let me know so I can close the PR and add the issue back to our backlog. Thank you!

**Summary of changes**: Improved deletion logic to treat "not found" errors as successful deletion rather than blocking finalizer removal.

* Before: ANY deletion error blocks finalizer removal
* After: Only real infrastructure errors (network, auth) block finalizer removal

### Change Summary
* 3 controllers updated: ApiCheck, Group, AlertChannel
* Added: isNotFoundError() utility function to detect 404/not found errors
* Added: unit tests
* Improved: ID validation (skip deletion attempts for empty IDs)