### PR TITLE
fix(ingress): ingress causing continuous error logs

### DIFF
--- a/api/checkly/v1alpha1/zz_generated.deepcopy.go
+++ b/api/checkly/v1alpha1/zz_generated.deepcopy.go
@@ -287,6 +287,11 @@ func (in *GroupSpec) DeepCopyInto(out *GroupSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.PrivateLocations != nil {
+		in, out := &in.PrivateLocations, &out.PrivateLocations
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.AlertChannels != nil {
 		in, out := &in.AlertChannels, &out.AlertChannels
 		*out = make([]string, len(*in))

--- a/api/checkly/v1alpha1/zz_generated.deepcopy.go
+++ b/api/checkly/v1alpha1/zz_generated.deepcopy.go
@@ -287,11 +287,6 @@ func (in *GroupSpec) DeepCopyInto(out *GroupSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.PrivateLocations != nil {
-		in, out := &in.PrivateLocations, &out.PrivateLocations
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
 	if in.AlertChannels != nil {
 		in, out := &in.AlertChannels, &out.AlertChannels
 		*out = make([]string, len(*in))


### PR DESCRIPTION
### Summary
Fix for regression from https://github.com/checkly/checkly-operator/issues/65 where disabled ingresses were causing continuous error logs.

TL;DR: Moves the enabled annotation check before gatherApiCheckData() to prevent errors when ingresses lack required group annotation. 

Confirmed locally: Ingresses without enabled annotation are silently ignored, no errors.

### Note
This PR was created with the help of Claude, please let me know if I'm on the wrong path here. 
